### PR TITLE
Fix: Update Ubuntu's torrent link(23.04)

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -37,7 +37,7 @@ _下图是使用我整理的 Tracker 列表下载BT的速度（all.txt）。_
 ![BitComet](https://cdn.staticaly.com/gh/XIU2/TrackersListCollection/master/img/zh-01.png)
 ![qBittorrentEE](https://cdn.staticaly.com/gh/XIU2/TrackersListCollection/master/img/zh-02.png)
 
-_可通过观察 **[ubuntu.torrent](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-desktop-amd64.iso.torrent)** 下载速度来**判断 BT 配置、网络**是否有问题，该热门资源不缺做种用户，如果**下载速度较慢**则可能有问题。_
+_可通过观察 **[ubuntu.torrent](https://releases.ubuntu.com/23.04/ubuntu-23.04-desktop-amd64.iso.torrent)** 下载速度来**判断 BT 配置、网络**是否有问题，该热门资源不缺做种用户，如果**下载速度较慢**则可能有问题。_
 
 ****
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ _The figure below shows the BT download speed after using Tracker. (all.txt)_
 ![BitComet](https://cdn.staticaly.com/gh/XIU2/TrackersListCollection/master/img/en-01.png)
 ![qBittorrentEE](https://cdn.staticaly.com/gh/XIU2/TrackersListCollection/master/img/en-02.png)
 
-_You can judge whether there is a problem with the BT configuration and network by observing the download speed of [**ubuntu.torrent**](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-desktop-amd64.iso.torrent). There are many users of this popular resource, and the download speed should be very fast under normal circumstances._
+_You can judge whether there is a problem with the BT configuration and network by observing the download speed of [**ubuntu.torrent**](https://releases.ubuntu.com/23.04/ubuntu-23.04-desktop-amd64.iso.torrent). There are many users of this popular resource, and the download speed should be very fast under normal circumstances._
 
 ****
 


### PR DESCRIPTION
ubuntu的链接老是失效，是不是可以考虑换一个？